### PR TITLE
add github templates for issues and PR

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+---
+name:
+about: Issue Tracker ID
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the issue**
+_A short description of what the issue is_
+_Include steps to reproduce if needed_
+
+**System Information:**
+_Please update accordingly_
+ - Operating System: [`macOS-10.14.14`]:
+ - Fink client version: [`0.0.1`]
+ - Occurred on which branch and with what commit: [`master-abc456d`]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+**IMPORTANT: Please create an issue first before opening a Pull Request.**
+Linked to issue(s): _put link_
+
+## What changes were proposed in this pull request?
+
+<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->
+
+How is the issue this PR is referenced against solved with this PR?
+
+## How was this patch tested?

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 
 script:
   # For sonar to run correctly
-  - git fetch --unshallow --quiet
+  # - git fetch --unshallow --quiet
 
   # Do nothing for the moment
   - python -c "import fink_client; print(fink_client.__version__)"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=fink-client&metric=alert_status)](https://sonarcloud.io/dashboard?id=fink-client) [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=fink-client&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=fink-client)
+[![Build Status](https://travis-ci.org/astrolabsoftware/fink-client.svg?branch=master)](https://travis-ci.org/astrolabsoftware/fink-client)
+[![codecov](https://codecov.io/gh/astrolabsoftware/fink-client/branch/master/graph/badge.svg)](https://codecov.io/gh/astrolabsoftware/fink-client) [![Documentation Status](https://readthedocs.org/projects/fink-broker/badge/?version=latest)](https://fink-broker.readthedocs.io/en/latest/?badge=latest)
+
 # Fink client
 
 `fink-client` is a light package to manipulate catalogs and alerts issued from the [fink broker](https://github.com/astrolabsoftware/fink-broker) programmatically.


### PR DESCRIPTION
Linked to issue(s): #3 

This PR adds templates for writing issues and PR in the fink-client repo. Inspired from the fink-broker templates.