### PR TITLE
Fix uncaught conditional in CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
 
   # Scan with sonarqube only if internal PR (i.e. no fork)
   # Note: this is unsatisfactory...
-  - if [ $TRAVIS_PULL_REQUEST == false ] || [ $TRAVIS_PULL_REQUEST_SLUG == "astrolabsoftware/fink-client"]; then
+  - if [ $TRAVIS_PULL_REQUEST == true ] || [ $TRAVIS_PULL_REQUEST_SLUG == "astrolabsoftware/fink-client"]; then
     coverage xml -i;
     sonar-scanner;
     fi


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #23 

## What changes were proposed in this pull request?

A forked build failed with this error:

    ERROR: Error during SonarQube Scanner execution
    ERROR: Not authorized. Please check the properties sonar.login and sonar.password.

    The command "if [ $TRAVIS_PULL_REQUEST == false ] || [ $TRAVIS_PULL_REQUEST_SLUG == "astrolabsoftware/fink-client"]; then coverage xml -i; sonar-scanner; fi" exited with 1.

The conditional should have caught that the tests was not a
TRAVIS_PULL_REQUEST or the TRAVIS_PULL_REQUEST_SLUG was not
astrolabsoftware/fink_client but was a fork repo instead

REF:

    https://travis-ci.com/tallamjr/fink-client/jobs/238010364

	modified:   .travis.yml

How is the issue this PR is referenced against solved with this PR?

By setting the logic to 'true' then sonar should only run when it is
a PR or when it is _not_ a forked repo.

## How was this patch tested?
Via travis -- https://travis-ci.com/tallamjr/fink-client/builds/128697685