### PR TITLE
Import consumer config from inside fink_consumer

### DIFF
--- a/bin/fink_consumer
+++ b/bin/fink_consumer
@@ -16,6 +16,7 @@
 """ Kafka consumer to listen and archive Fink streams """
 import argparse
 import time
+import importlib
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -23,7 +24,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from fink_client.consumer import AlertConsumer
-import fink_client.fink_client_conf_cloud as fcc
 
 def main():
     """ """
@@ -41,6 +41,15 @@ def main():
         '-outdir', type=str, default='.',
         help="Folder to store incoming alerts if --save is set. It must exist.")
     args = parser.parse_args(None)
+
+    # Import the configuration - not very satisfactory...
+    try:
+        fcc = importlib.import_module(
+            args.config.replace('/', '.').replace('.py', '')
+        )
+    except ModuleNotFoundError as e:
+        print(e)
+        print('Configuration file must be of the form fink_client/yourconf.py')
 
     myconfig = {
         "username": fcc.username,


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #41 

## What changes were proposed in this pull request?

`fink_consumer` now loads the config from `args.config`. Note that the config must be in `fink-client` to be loaded, and users must pass the relative path as `fink_consumer -config fink_client/config.py` - otherwise it won't be interpreted (it is not a satisfactory solution though...)
## How was this patch tested?
