### PR TITLE
Add possibility to use a custom schema when decoding the alerts

### DIFF
--- a/fink_client/scripts/fink_consumer.py
+++ b/fink_client/scripts/fink_consumer.py
@@ -46,6 +46,9 @@ def main():
     parser.add_argument(
         '-outdir', type=str, default='.',
         help="Folder to store incoming alerts if --save is set. It must exist.")
+    parser.add_argument(
+        '-schema', type=str, default=None,
+        help="Avro schema to decode the incoming alerts. Default is None (latest version downloaded from server)")
     args = parser.parse_args(None)
 
     # load user configuration
@@ -60,7 +63,11 @@ def main():
         myconfig['password'] = conf['password']
 
     # Instantiate a consumer
-    consumer = AlertConsumer(conf['mytopics'], myconfig)
+    if args.schema is None:
+        schema = None
+    else:
+        schema = args.schema
+    consumer = AlertConsumer(conf['mytopics'], myconfig, schema=schema)
 
     if args.available_topics:
         print(consumer.available_topics().keys())


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #68 

## What changes were proposed in this pull request?

In this PR, the user can manually specify a schema in `fink_consumer` to decode the alert. Helper is:

```
fink_consumer -h
usage: fink_consumer [-h] [--display] [-limit LIMIT] [--available_topics]
                     [--save] [-outdir OUTDIR] [-schema SCHEMA]

Kafka consumer to listen and archive Fink streams

optional arguments:
  -h, --help          show this help message and exit
  --display           If specified, print on screen information about incoming
                      alert.
  -limit LIMIT        If specified, download only `limit` alerts. Default is
                      None.
  --available_topics  If specified, print on screen information about
                      available topics.
  --save              If specified, save alert data on disk (Avro). See also
                      -outdir.
  -outdir OUTDIR      Folder to store incoming alerts if --save is set. It
                      must exist.
  -schema SCHEMA      Avro schema to decode the incoming alerts. Default is
                      None (latest version downloaded from server)
```

## How was this patch tested?

Manually