### PR TITLE
Update the display

### DIFF
--- a/fink_client/scripts/fink_consumer.py
+++ b/fink_client/scripts/fink_consumer.py
@@ -24,6 +24,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 
 import numpy as np
+from tabulate import tabulate
 
 from fink_client.consumer import AlertConsumer
 from fink_client.configuration import load_credentials
@@ -95,12 +96,13 @@ def main():
                 poll_number += 1
 
             if args.display and topic is not None:
-                print("-" * 65)
-                row = [
-                    time.ctime(), alert['timestamp'], topic, alert['objectId'],
+                utc = time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime())
+                table = [[
+                    alert['timestamp'], utc, topic, alert['objectId'],
                     alert['cdsxmatch'], alert['rfscore']
-                ]
-                print("{}|{:<25}|{:<10}|{:<15}|{:<10}|{:<5}|".format(*row))
+                ],]
+                headers = ['Emitted at (UTC)', 'Received at (UTC)', 'Topic', 'objectId', 'Simbad', 'RF score']
+                print(tabulate(table, headers, tablefmt="pretty"))
             elif args.display:
                 print('No alerts the last {} seconds'.format(maxtimeout))
     except KeyboardInterrupt:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pandas
 visdcc
 aplpy
 pyyaml
+tabulate


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #74 

## What changes were proposed in this pull request?

The display goes from

```
2021-03-05 11:00:40.000319|fink_early_sn_candidates_ztf|ZTF21aalcsng |0|0.687 |0.8705604076385498
```

to 

```
+----------------------------+---------------------+------------------------------+--------------+---------+----------+
|      Emitted at (UTC)      |  Received at (UTC)  |            Topic             |   objectId   | Simbad  | RF score |
+----------------------------+---------------------+------------------------------+--------------+---------+----------+
| 2021-03-07 06:03:14.002569 | 2021-03-10 22:05:56 | fink_early_sn_candidates_ztf | ZTF21aalekwo | Unknown |  0.913   |
+----------------------------+---------------------+------------------------------+--------------+---------+----------+
```

thanks to the use of the `tabulate` package.

## How was this patch tested?

Manually