### PR TITLE
Allow automatic Avro schema migration

### DIFF
--- a/fink_client/__init__.py
+++ b/fink_client/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 __version__ = "1.4"
-__schema_version__ = "distribution_schema_0p3-live.avsc"
+__schema_version__ = "distribution_schema_fink_ztf_{}.avsc"

--- a/fink_client/consumer.py
+++ b/fink_client/consumer.py
@@ -30,7 +30,7 @@ class AlertConsumer:
     High level Kafka consumer to receive alerts from Fink broker
     """
 
-    def __init__(self, topics: list, config: dict, schema=None):
+    def __init__(self, topics: list, config: dict, schema_path=None):
         """Creates an instance of `AlertConsumer`
 
         Parameters
@@ -50,7 +50,8 @@ class AlertConsumer:
         """
         self._topics = topics
         self._kafka_config = _get_kafka_config(config)
-        self._parsed_schema = _get_alert_schema(schema_path=schema)
+        self.schema_path = schema_path
+        # self._parsed_schema = _get_alert_schema(schema_path=schema_path)
         self._consumer = confluent_kafka.Consumer(self._kafka_config)
         self._consumer.subscribe(self._topics)
 
@@ -71,12 +72,12 @@ class AlertConsumer:
 
         Returns
         ----------
-        (topic, alert): tuple(str, dict)
-            returns (None, None) on timeout
+        (topic, alert, key): tuple(str, dict, str)
+            returns (None, None, None) on timeout
         """
         msg = self._consumer.poll(timeout)
         if msg is None:
-            return None, None
+            return None, None, None
 
         # msg.error() returns None or KafkaError
         if msg.error():
@@ -90,10 +91,28 @@ class AlertConsumer:
             raise AlertError(error_message)
 
         topic = msg.topic()
-        avro_alert = io.BytesIO(msg.value())
-        alert = _decode_avro_alert(avro_alert, self._parsed_schema)
 
-        return topic, alert
+        # decode the key if it is bytes
+        key = msg.key()
+        if type(key) == bytes:
+            key = key.decode('utf8')
+
+        # Get the schema
+        if self.schema_path is not None:
+            _parsed_schema = _get_alert_schema(schema_path=self.schema_path)
+        elif key is not None:
+            _parsed_schema = _get_alert_schema(key=key)
+        else:
+            msg = """
+            The message cannot be decoded as there is no key (None). Either specify a
+            key when writing the alert, or specify manually the schema path when
+            instantiating ``AlertConsumer`` (or from fink_consumer).
+            """
+            raise NotImplementedError(msg)
+        avro_alert = io.BytesIO(msg.value())
+        alert = _decode_avro_alert(avro_alert, _parsed_schema)
+
+        return topic, alert, key
 
     def consume(self, num_alerts: int = 1, timeout: float = -1) -> list:
         """ Consume and return list of messages
@@ -108,8 +127,8 @@ class AlertConsumer:
 
         Returns
         ----------
-        list: [tuple(str, dict)]
-            list of topic, alert
+        list: [tuple(str, dict, str)]
+            list of topic, alert, key
             returns an empty list on timeout
         """
         alerts = []
@@ -117,10 +136,28 @@ class AlertConsumer:
 
         for msg in msg_list:
             topic = msg.topic()
-            avro_alert = io.BytesIO(msg.value())
-            alert = _decode_avro_alert(avro_alert, self._parsed_schema)
 
-            alerts.append((topic, alert))
+            # decode the key if it is bytes
+            key = msg.key()
+            if type(key) == bytes:
+                key = key.decode('utf8')
+
+            # Get the schema
+            if self.schema_path is not None:
+                _parsed_schema = _get_alert_schema(schema_path=self.schema_path)
+            elif key is not None:
+                _parsed_schema = _get_alert_schema(key=key)
+            else:
+                msg = """
+                The message cannot be decoded as there is no key (None). Either specify a
+                key when writing the alert, or specify manually the schema path when
+                instantiating ``AlertConsumer`` (or from fink_consumer).
+                """
+                raise NotImplementedError(msg)
+            avro_alert = io.BytesIO(msg.value())
+            alert = _decode_avro_alert(avro_alert, _parsed_schema)
+
+            alerts.append((topic, alert, key))
 
         return alerts
 
@@ -128,7 +165,7 @@ class AlertConsumer:
             self, outdir: str, timeout: float = -1,
             overwrite: bool = False) -> (str, dict):
         """ Consume one message from Fink server, save alert on disk and
-        return (topic, alert)
+        return (topic, alert, key)
 
         Parameters
         ----------
@@ -147,12 +184,26 @@ class AlertConsumer:
             returns (None, None) on timeout
 
         """
-        topic, alert = self.poll(timeout)
+        topic, alert, key = self.poll(timeout)
+
+        # Get the schema
+        if self.schema_path is not None:
+            _parsed_schema = _get_alert_schema(schema_path=self.schema_path)
+        elif key is not None:
+            _parsed_schema = _get_alert_schema(key=key)
+        else:
+            msg = """
+            The message cannot be written as there is no key (None). Either specify a
+            key when writing the alert, or specify manually the schema path when
+            instantiating ``AlertConsumer`` (or from fink_consumer).
+            """
+            raise NotImplementedError(msg)
+
         if topic is not None:
             # print('Alert written at {}'.format(outdir))
-            write_alert(alert, self._parsed_schema, outdir, overwrite=overwrite)
+            write_alert(alert, _parsed_schema, outdir, overwrite=overwrite)
 
-        return topic, alert
+        return topic, alert, key
 
     def available_topics(self) -> dict:
         """ Return available broker topics

--- a/fink_client/scripts/fink_consumer.py
+++ b/fink_client/scripts/fink_consumer.py
@@ -68,7 +68,7 @@ def main():
         schema = None
     else:
         schema = args.schema
-    consumer = AlertConsumer(conf['mytopics'], myconfig, schema=schema)
+    consumer = AlertConsumer(conf['mytopics'], myconfig, schema_path=schema)
 
     if args.available_topics:
         print(consumer.available_topics().keys())
@@ -84,13 +84,13 @@ def main():
         while poll_number < maxpoll:
             if args.save:
                 # Save alerts on disk
-                topic, alert = consumer.poll_and_write(
+                topic, alert, key = consumer.poll_and_write(
                     outdir=args.outdir,
                     timeout=maxtimeout)
             else:
                 # TODO: this is useless to get it and done nothing
                 # why not thinking about handler like Comet?
-                topic, alert = consumer.poll(timeout=maxtimeout)
+                topic, alert, key = consumer.poll(timeout=maxtimeout)
 
             if topic is not None:
                 poll_number += 1

--- a/schemas/distribution_schema_fink_ztf_1.0_0.4.3.avsc
+++ b/schemas/distribution_schema_fink_ztf_1.0_0.4.3.avsc
@@ -1,0 +1,1356 @@
+{
+  "type": "record",
+  "name": "topLevelRecord",
+  "fields": [
+    {
+      "name": "schemavsn",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "publisher",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "objectId",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "candid",
+      "type": [
+        "long",
+        "null"
+      ]
+    },
+    {
+      "name": "candidate",
+      "type": {
+        "type": "record",
+        "name": "candidate",
+        "namespace": "topLevelRecord",
+        "fields": [
+          {
+            "name": "jd",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "fid",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "pid",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "diffmaglim",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "pdiffimfilename",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "programpi",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "programid",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "candid",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "isdiffpos",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "tblid",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "nid",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "rcid",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "field",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "xpos",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ypos",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ra",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "dec",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "magpsf",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sigmapsf",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "chipsf",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magap",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sigmagap",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "distnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sigmagnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "chinr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sharpnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sky",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magdiff",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "fwhm",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "classtar",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "mindtoedge",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magfromlim",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "seeratio",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "aimage",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "bimage",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "aimagerat",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "bimagerat",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "elong",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "nneg",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "nbad",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "rb",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ssdistnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ssmagnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ssnamenr",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "sumrat",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magapbig",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sigmagapbig",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ranr",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "decnr",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "sgmag1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "srmag1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "simag1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "szmag1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sgscore1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "distpsnr1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ndethist",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "ncovhist",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "jdstarthist",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "jdendhist",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "scorr",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "tooflag",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "objectidps1",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "objectidps2",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "sgmag2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "srmag2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "simag2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "szmag2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sgscore2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "distpsnr2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "objectidps3",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "sgmag3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "srmag3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "simag3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "szmag3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sgscore3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "distpsnr3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "nmtchps",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "rfid",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "jdstartref",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "jdendref",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "nframesref",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "rbversion",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "dsnrms",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ssnrms",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "dsdiff",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magzpsci",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magzpsciunc",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magzpscirms",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "nmatches",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "clrcoeff",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "clrcounc",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "zpclrcov",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "zpmed",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "clrmed",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "clrrms",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "neargaia",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "neargaiabright",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "maggaia",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "maggaiabright",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "exptime",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "drb",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "drbversion",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "prv_candidates",
+      "type": [
+        {
+          "type": "array",
+          "items": [
+            {
+              "type": "record",
+              "name": "prv_candidates",
+              "namespace": "topLevelRecord",
+              "fields": [
+                {
+                  "name": "jd",
+                  "type": [
+                    "double",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "fid",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "pid",
+                  "type": [
+                    "long",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "diffmaglim",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "pdiffimfilename",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "programpi",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "programid",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "candid",
+                  "type": [
+                    "long",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "isdiffpos",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "tblid",
+                  "type": [
+                    "long",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "nid",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "rcid",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "field",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "xpos",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "ypos",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "ra",
+                  "type": [
+                    "double",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "dec",
+                  "type": [
+                    "double",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magpsf",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sigmapsf",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "chipsf",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magap",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sigmagap",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "distnr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magnr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sigmagnr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "chinr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sharpnr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sky",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magdiff",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "fwhm",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "classtar",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "mindtoedge",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magfromlim",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "seeratio",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "aimage",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "bimage",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "aimagerat",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "bimagerat",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "elong",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "nneg",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "nbad",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "rb",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "ssdistnr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "ssmagnr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "ssnamenr",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sumrat",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magapbig",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sigmagapbig",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "ranr",
+                  "type": [
+                    "double",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "decnr",
+                  "type": [
+                    "double",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "scorr",
+                  "type": [
+                    "double",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magzpsci",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magzpsciunc",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magzpscirms",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "clrcoeff",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "clrcounc",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "rbversion",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              ]
+            },
+            "null"
+          ]
+        },
+        "null"
+      ]
+    },
+    {
+      "name": "cutoutScience",
+      "type": {
+        "type": "record",
+        "name": "cutoutScience",
+        "namespace": "topLevelRecord",
+        "fields": [
+          {
+            "name": "fileName",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "stampData",
+            "type": [
+              "bytes",
+              "null"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "cutoutTemplate",
+      "type": {
+        "type": "record",
+        "name": "cutoutTemplate",
+        "namespace": "topLevelRecord",
+        "fields": [
+          {
+            "name": "fileName",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "stampData",
+            "type": [
+              "bytes",
+              "null"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "cutoutDifference",
+      "type": {
+        "type": "record",
+        "name": "cutoutDifference",
+        "namespace": "topLevelRecord",
+        "fields": [
+          {
+            "name": "fileName",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "stampData",
+            "type": [
+              "bytes",
+              "null"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "timestamp",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "cdsxmatch",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "rfscore",
+      "type": [
+        "double",
+        "null"
+      ]
+    },
+    {
+      "name": "snn_snia_vs_nonia",
+      "type": [
+        "double",
+        "null"
+      ]
+    },
+    {
+      "name": "snn_sn_vs_all",
+      "type": [
+        "double",
+        "null"
+      ]
+    },
+    {
+      "name": "mulens",
+      "type": {
+        "type": "record",
+        "name": "mulens",
+        "namespace": "topLevelRecord",
+        "fields": [
+          {
+            "name": "class_1",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "ml_score_1",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "class_2",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "ml_score_2",
+            "type": [
+              "double",
+              "null"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "roid",
+      "type": [
+        "int",
+        "null"
+      ]
+    },
+    {
+      "name": "nalerthist",
+      "type": [
+        "int",
+        "null"
+      ]
+    },
+    {
+      "name": "fink_broker_version",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "fink_science_version",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  ]
+}

--- a/schemas/distribution_schema_fink_ztf_1.1_0.4.3.avsc
+++ b/schemas/distribution_schema_fink_ztf_1.1_0.4.3.avsc
@@ -1,0 +1,1363 @@
+{
+  "type": "record",
+  "name": "topLevelRecord",
+  "fields": [
+    {
+      "name": "schemavsn",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "publisher",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "objectId",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "candid",
+      "type": [
+        "long",
+        "null"
+      ]
+    },
+    {
+      "name": "candidate",
+      "type": {
+        "type": "record",
+        "name": "candidate",
+        "namespace": "topLevelRecord",
+        "fields": [
+          {
+            "name": "jd",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "fid",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "pid",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "diffmaglim",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "pdiffimfilename",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "programpi",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "programid",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "candid",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "isdiffpos",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "tblid",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "nid",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "rcid",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "field",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "xpos",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ypos",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ra",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "dec",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "magpsf",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sigmapsf",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "chipsf",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magap",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sigmagap",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "distnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sigmagnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "chinr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sharpnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sky",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magdiff",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "fwhm",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "classtar",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "mindtoedge",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magfromlim",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "seeratio",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "aimage",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "bimage",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "aimagerat",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "bimagerat",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "elong",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "nneg",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "nbad",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "rb",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ssdistnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ssmagnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ssnamenr",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "sumrat",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magapbig",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sigmagapbig",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ranr",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "decnr",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "sgmag1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "srmag1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "simag1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "szmag1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sgscore1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "distpsnr1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ndethist",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "ncovhist",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "jdstarthist",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "jdendhist",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "scorr",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "tooflag",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "objectidps1",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "objectidps2",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "sgmag2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "srmag2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "simag2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "szmag2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sgscore2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "distpsnr2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "objectidps3",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "sgmag3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "srmag3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "simag3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "szmag3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sgscore3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "distpsnr3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "nmtchps",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "rfid",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "jdstartref",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "jdendref",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "nframesref",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "rbversion",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "dsnrms",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ssnrms",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "dsdiff",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magzpsci",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magzpsciunc",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magzpscirms",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "nmatches",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "clrcoeff",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "clrcounc",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "zpclrcov",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "zpmed",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "clrmed",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "clrrms",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "neargaia",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "neargaiabright",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "maggaia",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "maggaiabright",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "exptime",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "drb",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "drbversion",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "prv_candidates",
+      "type": [
+        {
+          "type": "array",
+          "items": [
+            {
+              "type": "record",
+              "name": "prv_candidates",
+              "namespace": "topLevelRecord",
+              "fields": [
+                {
+                  "name": "jd",
+                  "type": [
+                    "double",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "fid",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "pid",
+                  "type": [
+                    "long",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "diffmaglim",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "pdiffimfilename",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "programpi",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "programid",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "candid",
+                  "type": [
+                    "long",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "isdiffpos",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "tblid",
+                  "type": [
+                    "long",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "nid",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "rcid",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "field",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "xpos",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "ypos",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "ra",
+                  "type": [
+                    "double",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "dec",
+                  "type": [
+                    "double",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magpsf",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sigmapsf",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "chipsf",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magap",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sigmagap",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "distnr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magnr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sigmagnr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "chinr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sharpnr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sky",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magdiff",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "fwhm",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "classtar",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "mindtoedge",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magfromlim",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "seeratio",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "aimage",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "bimage",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "aimagerat",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "bimagerat",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "elong",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "nneg",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "nbad",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "rb",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "ssdistnr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "ssmagnr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "ssnamenr",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sumrat",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magapbig",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sigmagapbig",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "ranr",
+                  "type": [
+                    "double",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "decnr",
+                  "type": [
+                    "double",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "scorr",
+                  "type": [
+                    "double",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magzpsci",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magzpsciunc",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magzpscirms",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "clrcoeff",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "clrcounc",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "rbversion",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              ]
+            },
+            "null"
+          ]
+        },
+        "null"
+      ]
+    },
+    {
+      "name": "cutoutScience",
+      "type": {
+        "type": "record",
+        "name": "cutoutScience",
+        "namespace": "topLevelRecord",
+        "fields": [
+          {
+            "name": "fileName",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "stampData",
+            "type": [
+              "bytes",
+              "null"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "cutoutTemplate",
+      "type": {
+        "type": "record",
+        "name": "cutoutTemplate",
+        "namespace": "topLevelRecord",
+        "fields": [
+          {
+            "name": "fileName",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "stampData",
+            "type": [
+              "bytes",
+              "null"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "cutoutDifference",
+      "type": {
+        "type": "record",
+        "name": "cutoutDifference",
+        "namespace": "topLevelRecord",
+        "fields": [
+          {
+            "name": "fileName",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "stampData",
+            "type": [
+              "bytes",
+              "null"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "timestamp",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "cdsxmatch",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "rfscore",
+      "type": [
+        "double",
+        "null"
+      ]
+    },
+    {
+      "name": "snn_snia_vs_nonia",
+      "type": [
+        "double",
+        "null"
+      ]
+    },
+    {
+      "name": "snn_sn_vs_all",
+      "type": [
+        "double",
+        "null"
+      ]
+    },
+    {
+      "name": "mulens",
+      "type": {
+        "type": "record",
+        "name": "mulens",
+        "namespace": "topLevelRecord",
+        "fields": [
+          {
+            "name": "class_1",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "ml_score_1",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "class_2",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "ml_score_2",
+            "type": [
+              "double",
+              "null"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "roid",
+      "type": [
+        "int",
+        "null"
+      ]
+    },
+    {
+      "name": "nalerthist",
+      "type": [
+        "int",
+        "null"
+      ]
+    },
+    {
+      "name": "fink_broker_version",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "fink_science_version",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "knscore",
+      "type": [
+        "double",
+        "null"
+      ]
+    }
+  ]
+}

--- a/schemas/distribution_schema_fink_ztf_1.1_0.4.4.avsc
+++ b/schemas/distribution_schema_fink_ztf_1.1_0.4.4.avsc
@@ -1,0 +1,1363 @@
+{
+  "type": "record",
+  "name": "topLevelRecord",
+  "fields": [
+    {
+      "name": "schemavsn",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "publisher",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "objectId",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "candid",
+      "type": [
+        "long",
+        "null"
+      ]
+    },
+    {
+      "name": "candidate",
+      "type": {
+        "type": "record",
+        "name": "candidate",
+        "namespace": "topLevelRecord",
+        "fields": [
+          {
+            "name": "jd",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "fid",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "pid",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "diffmaglim",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "pdiffimfilename",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "programpi",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "programid",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "candid",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "isdiffpos",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "tblid",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "nid",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "rcid",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "field",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "xpos",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ypos",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ra",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "dec",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "magpsf",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sigmapsf",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "chipsf",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magap",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sigmagap",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "distnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sigmagnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "chinr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sharpnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sky",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magdiff",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "fwhm",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "classtar",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "mindtoedge",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magfromlim",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "seeratio",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "aimage",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "bimage",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "aimagerat",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "bimagerat",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "elong",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "nneg",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "nbad",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "rb",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ssdistnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ssmagnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ssnamenr",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "sumrat",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magapbig",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sigmagapbig",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ranr",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "decnr",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "sgmag1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "srmag1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "simag1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "szmag1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sgscore1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "distpsnr1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ndethist",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "ncovhist",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "jdstarthist",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "jdendhist",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "scorr",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "tooflag",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "objectidps1",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "objectidps2",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "sgmag2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "srmag2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "simag2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "szmag2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sgscore2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "distpsnr2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "objectidps3",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "sgmag3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "srmag3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "simag3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "szmag3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sgscore3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "distpsnr3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "nmtchps",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "rfid",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "jdstartref",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "jdendref",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "nframesref",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "rbversion",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "dsnrms",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ssnrms",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "dsdiff",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magzpsci",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magzpsciunc",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magzpscirms",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "nmatches",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "clrcoeff",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "clrcounc",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "zpclrcov",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "zpmed",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "clrmed",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "clrrms",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "neargaia",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "neargaiabright",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "maggaia",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "maggaiabright",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "exptime",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "drb",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "drbversion",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "prv_candidates",
+      "type": [
+        {
+          "type": "array",
+          "items": [
+            {
+              "type": "record",
+              "name": "prv_candidates",
+              "namespace": "topLevelRecord",
+              "fields": [
+                {
+                  "name": "jd",
+                  "type": [
+                    "double",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "fid",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "pid",
+                  "type": [
+                    "long",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "diffmaglim",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "pdiffimfilename",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "programpi",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "programid",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "candid",
+                  "type": [
+                    "long",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "isdiffpos",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "tblid",
+                  "type": [
+                    "long",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "nid",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "rcid",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "field",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "xpos",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "ypos",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "ra",
+                  "type": [
+                    "double",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "dec",
+                  "type": [
+                    "double",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magpsf",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sigmapsf",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "chipsf",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magap",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sigmagap",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "distnr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magnr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sigmagnr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "chinr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sharpnr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sky",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magdiff",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "fwhm",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "classtar",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "mindtoedge",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magfromlim",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "seeratio",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "aimage",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "bimage",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "aimagerat",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "bimagerat",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "elong",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "nneg",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "nbad",
+                  "type": [
+                    "int",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "rb",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "ssdistnr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "ssmagnr",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "ssnamenr",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sumrat",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magapbig",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "sigmagapbig",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "ranr",
+                  "type": [
+                    "double",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "decnr",
+                  "type": [
+                    "double",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "scorr",
+                  "type": [
+                    "double",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magzpsci",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magzpsciunc",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "magzpscirms",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "clrcoeff",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "clrcounc",
+                  "type": [
+                    "float",
+                    "null"
+                  ]
+                },
+                {
+                  "name": "rbversion",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              ]
+            },
+            "null"
+          ]
+        },
+        "null"
+      ]
+    },
+    {
+      "name": "cutoutScience",
+      "type": {
+        "type": "record",
+        "name": "cutoutScience",
+        "namespace": "topLevelRecord",
+        "fields": [
+          {
+            "name": "fileName",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "stampData",
+            "type": [
+              "bytes",
+              "null"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "cutoutTemplate",
+      "type": {
+        "type": "record",
+        "name": "cutoutTemplate",
+        "namespace": "topLevelRecord",
+        "fields": [
+          {
+            "name": "fileName",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "stampData",
+            "type": [
+              "bytes",
+              "null"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "cutoutDifference",
+      "type": {
+        "type": "record",
+        "name": "cutoutDifference",
+        "namespace": "topLevelRecord",
+        "fields": [
+          {
+            "name": "fileName",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "stampData",
+            "type": [
+              "bytes",
+              "null"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "timestamp",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "cdsxmatch",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "rfscore",
+      "type": [
+        "double",
+        "null"
+      ]
+    },
+    {
+      "name": "snn_snia_vs_nonia",
+      "type": [
+        "double",
+        "null"
+      ]
+    },
+    {
+      "name": "snn_sn_vs_all",
+      "type": [
+        "double",
+        "null"
+      ]
+    },
+    {
+      "name": "mulens",
+      "type": {
+        "type": "record",
+        "name": "mulens",
+        "namespace": "topLevelRecord",
+        "fields": [
+          {
+            "name": "class_1",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "ml_score_1",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "class_2",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "ml_score_2",
+            "type": [
+              "double",
+              "null"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "roid",
+      "type": [
+        "int",
+        "null"
+      ]
+    },
+    {
+      "name": "nalerthist",
+      "type": [
+        "int",
+        "null"
+      ]
+    },
+    {
+      "name": "fink_broker_version",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "fink_science_version",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "knscore",
+      "type": [
+        "double",
+        "null"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #77 

## What changes were proposed in this pull request?

This PR changes the way schemas are handled. Now all Avro alerts contains a `key` entry that specifies the version of the schemas used by the producer to encode the alert. This key then is automatically used to retrieve the corresponding schema to decode the alert. 

Missing:
- [x] Push schema `1.1_0.4.3` that corresponds to the addition of Kilonova classifier

## How was this patch tested?

Manually
