### PR TITLE
Update writer: objectId_candid.avro is the new default

### DIFF
--- a/docs/livestream_manual.md
+++ b/docs/livestream_manual.md
@@ -67,8 +67,8 @@ Once alerts are saved, you can open it and explore the content. We wrote a small
 
 ```bash
 # access help using `fink_alert_viewer -h`
-# Adapt the filename accordingly
-fink_alert_viewer -filename alertDB/ZTF21aancozh.avro
+# Adapt the filename accordingly -- it is <objectId>_<candid>.avro
+fink_alert_viewer -filename alertDB/ZTF21aaqkqwq_1549473362115015004.avro
 ```
 
 of course, you can develop your own tools based on this one! Note Apache Avro is not something supported by default in Pandas for example, so we provide a small utilities to load alerts more easily:
@@ -77,7 +77,7 @@ of course, you can develop your own tools based on this one! Note Apache Avro is
 from fink_client.avroUtils import AlertReader
 
 # you can also specify one folder with several alerts directly
-r = AlertReader('data/ZTF17aaadlhe.avro')
+r = AlertReader('alertDB/ZTF21aaqkqwq_1549473362115015004.avro')
 
 # convert alert to Pandas DataFrame
 r.to_pandas()

--- a/fink_client/avroUtils.py
+++ b/fink_client/avroUtils.py
@@ -221,7 +221,7 @@ def write_alert(alert: dict, schema: str, path: str, overwrite: bool = False):
       ...
     OSError: ./ZTF19acihgng.avro already exists!
     """
-    alert_filename = os.path.join(path, "{}.avro".format(alert["objectId"]))
+    alert_filename = os.path.join(path, "{}_{}.avro".format(alert["objectId"], alert["candidate"]["candid"]))
 
     if type(schema) == str:
         schema = _get_alert_schema(schema)


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #89 

## What changes were proposed in this pull request?

This PR changes the name of the output files from `objectId.avro` to `objectId_candid.avro` to avoid clash for alerts from the same object.

## How was this patch tested?

Manually