### PR TITLE
Bump to 2.3

### DIFF
--- a/fink_client/__init__.py
+++ b/fink_client/__init__.py
@@ -12,5 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "2.2"
+__version__ = "2.3"
 __schema_version__ = "distribution_schema_fink_ztf_{}.avsc"


### PR DESCRIPTION
### 2.2 to 2.3
- Update writer: objectId_candid.avro is the new default #90 