### PR TITLE
Update documentation to explicitly mention auth parameter translation for Kafka

### DIFF
--- a/fink_client/consumer.py
+++ b/fink_client/consumer.py
@@ -33,6 +33,10 @@ class AlertConsumer:
     def __init__(self, topics: list, config: dict, schema_path=None):
         """Creates an instance of `AlertConsumer`
 
+        Note we are currently using SASL for the user authentication.
+        `config` parameters get then translated for Kafka.
+        For lower level usage, see `_get_kafka_config`
+
         Parameters
         ----------
         topics : list of str


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #101 

## What changes were proposed in this pull request?

This PR update the documentation of the `AlertConsumer` class to make explicit the authentication parameter translation for Kafka.

## How was this patch tested?

--