### PR TITLE
Allow reading list of avro files

### DIFF
--- a/fink_client/avroUtils.py
+++ b/fink_client/avroUtils.py
@@ -61,6 +61,11 @@ class AlertReader():
     >>> print('{} alerts decoded'.format(len(r.to_list())))
     3 alerts decoded
 
+    If you give a list of files
+    >>> r = AlertReader(avro_list)
+    >>> print('{} alerts decoded'.format(len(r.to_list())))
+    2 alerts decoded
+
     """
     def __init__(self, path: str):
         """ Initialise the AlertReader class """
@@ -81,7 +86,9 @@ class AlertReader():
         else:
             path = self.path
 
-        if os.path.isdir(path):
+        if isinstance(path, list):
+            self.filenames = path
+        elif os.path.isdir(path):
             self.filenames = glob.glob(os.path.join(path, '*.avro'))
         elif path == '':
             print('WARNING: path to avro files is empty')
@@ -396,6 +403,7 @@ if __name__ == "__main__":
     args['avro_single_alert'] = 'datatest/ZTF19acihgng.avro'
     args['avro_multi_file'] = 'datatest/avro_multi_alerts.avro'
     args['avro_multi_file2'] = 'datatest/avro_multi_alerts_other.avro'
+    args['avro_list'] = ['datatest/ZTF19acihgng.avro', 'datatest/ZTF19acyfkzd.avro']
     args['avro_folder'] = 'datatest'
     args['schema_path'] = 'schemas/distribution_schema_0p2.avsc'
 


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #115 

## What changes were proposed in this pull request?

Now you can read list of Avro files, assuming they all have the same schema:

```python
filenames = ['file1.avro', 'folder/file2.avro']
r = AlertReader(filename)
len(r.to_list())
# 2
```

## How was this patch tested?

manually