### PR TITLE
Remove dependency to aplpy

### DIFF
--- a/fink_client/visualisation.py
+++ b/fink_client/visualisation.py
@@ -19,13 +19,12 @@ import gzip
 import matplotlib.pyplot as plt
 
 from astropy.io import fits
-import aplpy
 
 import numpy as np
 
 def plot_cutout(
         stamp: bytes, stretch: str = 'arcsinh', vmid: float = None,
-        fig=None, subplot=None, **kwargs) -> aplpy.FITSFigure:
+        fig=None, subplot=None, **kwargs):
     """ Plot one cutout contained in an alert (2D array)
 
     Adapted from ZTF alert tools.
@@ -43,10 +42,17 @@ def plot_cutout(
                 subplot = (1, 1, 1)
             if vmid is None:
                 vmid = np.median(hdul[0].data)
-            ffig = aplpy.FITSFigure(
-                hdul[0], figure=fig, subplot=subplot, **kwargs)
-            ffig.show_grayscale(stretch=stretch, vmid=vmid)
-    return ffig
+
+            ax = fig.add_subplot(*subplot)
+
+            # Update graph data for stamps
+            data = np.nan_to_num(hdul[0].data)
+
+            data = data[::-1]
+
+            ax.imshow(data)
+
+    return ax
 
 def show_stamps(alert: dict, fig=None):
     """ Plot the 3 cutouts contained in an alert.

--- a/fink_client/visualisation.py
+++ b/fink_client/visualisation.py
@@ -22,9 +22,7 @@ from astropy.io import fits
 
 import numpy as np
 
-def plot_cutout(
-        stamp: bytes, stretch: str = 'arcsinh', vmid: float = None,
-        fig=None, subplot=None, **kwargs):
+def plot_cutout(stamp: bytes, fig=None, subplot=None, **kwargs):
     """ Plot one cutout contained in an alert (2D array)
 
     Adapted from ZTF alert tools.
@@ -40,8 +38,6 @@ def plot_cutout(
                 fig = plt.figure(figsize=(4, 4))
             if subplot is None:
                 subplot = (1, 1, 1)
-            if vmid is None:
-                vmid = np.median(hdul[0].data)
 
             ax = fig.add_subplot(*subplot)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ coveralls
 codecov
 confluent-kafka
 fastavro
-astropy<=4.3.1
+astropy
 pandas
 visdcc
 aplpy


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #120 

## What changes were proposed in this pull request?

Replace calls to aplpy by matplotlib. Note that we do not convolve data anymore, nor apply stretch.

## How was this patch tested?

Manually