### PR TITLE
Force ignore_missing_simple to True

### DIFF
--- a/fink_client/visualisation.py
+++ b/fink_client/visualisation.py
@@ -33,7 +33,7 @@ def plot_cutout(stamp: bytes, fig=None, subplot=None, **kwargs):
         Cutout data as raw binary from the alert
     """
     with gzip.open(io.BytesIO(stamp), 'rb') as f:
-        with fits.open(io.BytesIO(f.read())) as hdul:
+        with fits.open(io.BytesIO(f.read()), ignore_missing_simple=True) as hdul:
             if fig is None:
                 fig = plt.figure(figsize=(4, 4))
             if subplot is None:


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #132 

## What changes were proposed in this pull request?

Open FITS files with `ignore_missing_simple=True`

## How was this patch tested?

Manually, for astropy==4.3.1