### PR TITLE
Enable partitioning by classId

### DIFF
--- a/fink_client/__init__.py
+++ b/fink_client/__init__.py
@@ -12,5 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "4.1"
+__version__ = "4.2"
 __schema_version__ = "distribution_schema_fink_ztf_{}.avsc"

--- a/fink_client/scripts/fink_datatransfer.py
+++ b/fink_client/scripts/fink_datatransfer.py
@@ -46,7 +46,7 @@ def main():
         help="Folder to store incoming alerts. It will be created if it does not exist.")
     parser.add_argument(
         '-partitionby', type=str, default='time',
-        help="Partition data by `time` (year=YYYY/month=MM/day=DD), or `finkclass` (finkclass=CLASS), or `tnsclass` (tnsclass=CLASS). Default is time.")
+        help="Partition data by `time` (year=YYYY/month=MM/day=DD), or `finkclass` (finkclass=CLASS), or `tnsclass` (tnsclass=CLASS). `classId` is also available for ELASTiCC data. Default is time.")
     parser.add_argument(
         '-batchsize', type=int, default=1000,
         help="Maximum number of alert within the `maxtimeout` (see conf). Default is 1000 alerts.")


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #159 

## What changes were proposed in this pull request?

Users can now poll ELASTiCC data, and partition by `classId` using `fink_datatransfer`.

## How was this patch tested?

Manually