### PR TITLE
Error return offsets

### DIFF
--- a/fink_client/consumer.py
+++ b/fink_client/consumer.py
@@ -335,8 +335,8 @@ def return_offsets(consumer, topic, waitfor=1, timeout=10, verbose=False):
         else:
             lag = "%d" % (hi - partition.offset)
         #
-        total_offsets = partition.offset
-        total_lag = int(lag)
+        total_offsets = total_offsets + partition.offset
+        total_lag = total_lag + int(lag)
 
         if verbose:
             print("%-50s  %9s  %9s" % (

--- a/fink_client/consumer.py
+++ b/fink_client/consumer.py
@@ -334,7 +334,7 @@ def return_offsets(consumer, topic, waitfor=1, timeout=10, verbose=False):
             partition.offset = 0
         else:
             lag = "%d" % (hi - partition.offset)
-
+        #
         total_offsets = partition.offset
         total_lag = int(lag)
 


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): https://github.com/astrolabsoftware/fink-client/issues/178

## What changes were proposed in this pull request?

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->
total_offsets = total_offsets + partition.offset instead of 
total_offsets = partition.offset
and same for total_lag

Now the function "return_offsets" return the total number of messages committed across all partitions and the remaining messages in the topic

How is the issue this PR is referenced against solved with this PR? 
solved

## How was this patch tested?
No test
