### PR TITLE
Add new functionalities to reset offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,28 +48,31 @@ Once you have your credentials, you are ready to poll streams! You can easily ac
 
 ```bash
 fink_consumer -h
-usage: fink_consumer [-h] [--display] [-limit LIMIT] [--available_topics]
-                     [--save] [-outdir OUTDIR] [-schema SCHEMA]
-                     [--dump_schema]
+usage: fink_consumer [-h] [--display] [--display_statistics] [-limit LIMIT]
+                     [--available_topics] [--save] [-outdir OUTDIR]
+                     [-schema SCHEMA] [--dump_schema] [-start_at START_AT]
 
-Kafka consumer to listen and archive Fink streams from the Livestream
-service
+Kafka consumer to listen and archive Fink streams from the Livestream service
 
 optional arguments:
-  -h, --help          show this help message and exit
-  --display           If specified, print on screen information about
-                      incoming alert.
-  -limit LIMIT        If specified, download only `limit` alerts. Default is
-                      None.
-  --available_topics  If specified, print on screen information about
-                      available topics.
-  --save              If specified, save alert data on disk (Avro). See also
-                      -outdir.
-  -outdir OUTDIR      Folder to store incoming alerts if --save is set. It
-                      must exist.
-  -schema SCHEMA      Avro schema to decode the incoming alerts. Default is
-                      None (version taken from each alert)
-  --dump_schema       If specified, save the schema on disk (json file)
+  -h, --help            show this help message and exit
+  --display             If specified, print on screen information about
+                        incoming alert.
+  --display_statistics  If specified, print on screen information about queues,
+                        and exit.
+  -limit LIMIT          If specified, download only `limit` alerts. Default is
+                        None.
+  --available_topics    If specified, print on screen information about
+                        available topics.
+  --save                If specified, save alert data on disk (Avro). See also
+                        -outdir.
+  -outdir OUTDIR        Folder to store incoming alerts if --save is set. It
+                        must exist.
+  -schema SCHEMA        Avro schema to decode the incoming alerts. Default is
+                        None (version taken from each alert)
+  --dump_schema         If specified, save the schema on disk (json file)
+  -start_at START_AT    If specified, reset offsets to 0 (`earliest`) or empty
+                        queue (`latest`).
 ```
 
 You can also look at an alert on the disk:

--- a/fink_client/__init__.py
+++ b/fink_client/__init__.py
@@ -12,5 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "8.0"
+__version__ = "8.1"
 __schema_version__ = "distribution_schema_fink_ztf_{}.avsc"

--- a/fink_client/avro_utils.py
+++ b/fink_client/avro_utils.py
@@ -245,6 +245,12 @@ def write_alert(
     path: str
         Folder that will contain the alert. The filename will always be
         <objectID>.avro
+    overwrite: bool, optional
+        If True, overwrite existing alert. Default is False.
+    id1: str, optional
+        First prefix for alert name: {id1}_{id2}.avro
+    id2: str, optional
+        Second prefix for alert name: {id1}_{id2}.avro
 
     Examples
     --------

--- a/tests/test.py
+++ b/tests/test.py
@@ -95,7 +95,7 @@ class TestComponents(unittest.TestCase):
         myconfig = {
             "username": "Alice",
             "password": "Alice-secret",
-            "group_id": "test_group"
+            "group.id": "test_group"
         }
         kafka_config = _get_kafka_config(myconfig)
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -56,7 +56,7 @@ class TestIntegration(unittest.TestCase):
 
         myconfig = {
             'bootstrap.servers': kafka_servers,
-            'group_id': conf['group_id']}
+            'group.id': conf['group_id']}
 
         self.consumer = AlertConsumer(mytopics, myconfig, schema_path=schema_path)
 


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #146 

## What changes were proposed in this pull request?

### Checking offsets

You can now check where you are on the different queues, that is retrieving the offsets for each topic that you are polling:

```bash
fink_consumer --display_statistics

Topic [Partition]                                   Committed        Lag
========================================================================
fink_sso_ztf_candidates_ztf  [4]                            1        972
------------------------------------------------------------------------
Total for fink_sso_ztf_candidates_ztf                       1        972
------------------------------------------------------------------------

Topic [Partition]                                   Committed        Lag
========================================================================
------------------------------------------------------------------------
Total for fink_sso_fink_candidates_ztf                      0          2
------------------------------------------------------------------------
```

In this example, I have two topic, `fink_sso_ztf_candidates_ztf` and `fink_sso_fink_candidates_ztf`.

For the first topic, there is one active partition on the remote Kafka cluster that served data (number `[4]`). I polled 1 alert (`Committed`), and there are `972` remaining alerts to be polled (`Lag`). As there is only one active partition on the remote Kafka cluster, the total is the same (there could be up to 10 active partitions). For the second topic, I did not start polling as `0` alert has been `Committed`.

### Resetting offsets

Sometimes you might want to poll again alerts, that is restarting to poll from the beginning of a queue. For this, you can use:

```bash
fink_consumer --display -start_at earliest
Resetting offsets to BEGINNING
...
assign TopicPartition{topic=fink_sso_fink_candidates_ztf,partition=0,offset=0,leader_epoch=None,error=None}
...
assign TopicPartition{topic=fink_sso_ztf_candidates_ztf,partition=0,offset=0,leader_epoch=None,error=None}
...
# poll restarts at the first offset
```

All your topic partitions will be reset to the starting offset (`0` in this case). Similarly, you can empty all topics, and restarting polling from the last offset:

```bash
fink_consumer --display -start_at latest
...
assign TopicPartition{topic=fink_sso_fink_candidates_ztf,partition=0,offset=0,leader_epoch=None,error=None}
...
assign TopicPartition{topic=fink_sso_fink_candidates_ztf,partition=4,offset=2,leader_epoch=None,error=None}
...
assign TopicPartition{topic=fink_sso_ztf_candidates_ztf,partition=4,offset=973,leader_epoch=None,error=None}
...
No alerts the last 10 seconds
...
```

Empty partitions will have `offset=0`, but others will have their offset to the latest one. The client will then wait for new data to come. Note that the reset will be actually triggered on the next poll. Hence the command `fink_consumer --display_statistics` will not right away display the reset offsets.
This is particularly useful after a bug in the topic (malformed alerts pushed), and you want a fresh restart.

## How was this patch tested?

Manual