### PR TITLE
Add new option to dump schema

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install add-ons
       run: |
-        sudo apt-get install python3-testresources
+        sudo apt-get install python3-testresources docker-compose
     - name: Set up env [1/2]
       run: |
         echo "FINK_CLIENT_HOME=$GITHUB_WORKSPACE" >> $GITHUB_ENV

--- a/fink_client/scripts/fink_datatransfer.py
+++ b/fink_client/scripts/fink_datatransfer.py
@@ -21,6 +21,7 @@ import io
 import argparse
 import logging
 import psutil
+import json
 
 from tqdm import trange
 
@@ -285,6 +286,11 @@ def main():
         help="If specified, restart downloading from the 1st alert in the stream. Default is False.",
     )
     parser.add_argument(
+        "--dump_schema",
+        action="store_true",
+        help="If specified, save the schema on disk (json file)",
+    )
+    parser.add_argument(
         "--verbose",
         action="store_true",
         help="If specified, print on screen information about the consuming.",
@@ -353,6 +359,10 @@ def main():
             "No schema found -- wait a few seconds and relaunch. If the error persists, maybe the queue is empty."
         )
     else:
+        if args.dump_schema:
+            filename = "schema_{}.json".format(args.topic)
+            with open(filename, "w") as json_file:
+                json.dump(schema, json_file, sort_keys=True, indent=4)
         nbpart = return_npartitions(args.topic, kafka_config)
         print("Number of partitions for topic {}: {}".format(args.topic, nbpart))
         available = Queue()


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #206 

## What changes were proposed in this pull request?

Add a new option for the data transfer service to dump schema on disk:

```bash
fink_datatransfer [options] --dump_schema
```

The option will produce a json file on disk whose name is `schema_<topic name>.json`. Schema can be inspected using e.g.:

```bash
cat filename.json | jq
```

## How was this patch tested?

local