### PR TITLE
Check topic name is following convention for the Data Transfer service

### DIFF
--- a/fink_client/scripts/fink_datatransfer.py
+++ b/fink_client/scripts/fink_datatransfer.py
@@ -305,6 +305,16 @@ def main():
         )
         sys.exit()
 
+    if not args.topic.startswith("ftransfer"):
+        msg = """
+{} is not a valid topic name. 
+Topic name must start with `ftransfer_`.
+Check the webpage on which you submit the job, 
+and open the tab `Get your data` to retrieve the topic.
+        """.format(args.topic)
+        print(msg)
+        sys.exit()
+
     # load user configuration
     conf = load_credentials()
 


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #205 

## What changes were proposed in this pull request?

Check for valid topic name. Warn the user, and redirect to webpage to read the topic name. Note that it is still using `print` instead of `logging`.

## How was this patch tested?

Local
