### PR TITLE
Add time partitioning and logger

### DIFF
--- a/fink_client/logger.py
+++ b/fink_client/logger.py
@@ -1,0 +1,54 @@
+# Copyright 2025 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from logging import Logger
+
+
+def get_fink_logger(name: str = "test", log_level: str = "INFO") -> Logger:
+    """Initialise python logger. Suitable for both driver and executors.
+
+    Parameters
+    ----------
+    name : str
+        Name of the application to be logged. Typically __name__ of a
+        function or module.
+    log_level : str
+        Minimum level of log wanted: DEBUG, INFO, WARNING, ERROR, CRITICAL, OFF
+
+    Returns
+    -------
+    logger : logging.Logger
+        Python Logger
+
+    Examples
+    --------
+    >>> log = get_fink_logger(__name__, "INFO")
+    >>> log.info("Hi!")
+    """
+    # Format of the log message to be printed
+    FORMAT = "%(asctime)-15s "
+    FORMAT += "%(levelname)s "
+    FORMAT += "%(message)s"
+
+    # Date format
+    DATEFORMAT = "%y/%m/%d %H:%M:%S"
+
+    logging.basicConfig(format=FORMAT, datefmt=DATEFORMAT)
+    logger = logging.getLogger(name)
+
+    # Set the minimum log level
+    logger.setLevel(log_level)
+
+    return logger

--- a/fink_client/scripts/fink_consumer.py
+++ b/fink_client/scripts/fink_consumer.py
@@ -99,9 +99,7 @@ def main():
     if args.display_statistics:
         print()
         for topic in conf["mytopics"]:
-            total_lag, total_offset = print_offsets(
-                myconfig, topic, conf["maxtimeout"], verbose=True
-            )
+            _, _ = print_offsets(myconfig, topic, conf["maxtimeout"], verbose=True)
             print()
         sys.exit(0)
 
@@ -117,7 +115,7 @@ def main():
             def assign_offset(consumer, partitions):
                 print("Resetting offsets to BEGINNING")
                 for p in partitions:
-                    low, high = consumer.get_watermark_offsets(p)
+                    low, _ = consumer.get_watermark_offsets(p)
                     p.offset = low
                     print("assign", p)
                 consumer.assign(partitions)
@@ -127,7 +125,7 @@ def main():
             def assign_offset(consumer, partitions):
                 print("Resetting offsets to END")
                 for p in partitions:
-                    low, high = consumer.get_watermark_offsets(p)
+                    _, high = consumer.get_watermark_offsets(p)
                     p.offset = high
                     print("assign", p)
                 consumer.assign(partitions)
@@ -166,13 +164,13 @@ def main():
         while poll_number < maxpoll:
             if args.save:
                 # Save alerts on disk
-                topic, alert, key = consumer.poll_and_write(
+                topic, alert, _ = consumer.poll_and_write(
                     outdir=args.outdir, timeout=maxtimeout, overwrite=True
                 )
             else:
                 # TODO: this is useless to get it and done nothing
                 # why not thinking about handler like Comet?
-                topic, alert, key = consumer.poll(timeout=maxtimeout)
+                topic, alert, _ = consumer.poll(timeout=maxtimeout)
 
             if topic is not None:
                 poll_number += 1


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #213 

## What changes were proposed in this pull request?

This PR adds the partitioning by time, e.g.

```bash
fink_datatransfer.py \
    -topic ftransfer_ztf_2025-06-22_930024 \
    -outdir ftransfer_ztf_2025-06-22_930024 \
    -partitionby time \
    --verbose
```

It also prevents user polling to crash if `finkclass` is not in the payload by switching to time partitioning by default:

```
# assuming the user did not select `finkclass`
fink_datatransfer.py \
    -topic ftransfer_ztf_2025-06-22_930024 \
    -outdir ftransfer_ztf_2025-06-22_930024 \
    -partitionby finkclass \
    --verbose

25/06/22 23:25:46 WARNING finkclass not found. Applying time partitioning.
...
```
## How was this patch tested?

Manual