### PR TITLE
Data Transfer: Enable no partitioning

### DIFF
--- a/fink_client/scripts/fink_datatransfer.py
+++ b/fink_client/scripts/fink_datatransfer.py
@@ -334,7 +334,12 @@ def main():
     )
     args = parser.parse_args(None)
 
-    if args.partitionby is not None and args.partitionby not in ["time", "finkclass", "tnsclass", "classId"]:
+    if args.partitionby is not None and args.partitionby not in [
+        "time",
+        "finkclass",
+        "tnsclass",
+        "classId",
+    ]:
         _LOG.error(
             "{} is an unknown partitioning. `-partitionby` should be in ['time', 'finkclass', 'tnsclass', 'classId']".format(
                 args.partitionby

--- a/fink_client/scripts/fink_datatransfer.py
+++ b/fink_client/scripts/fink_datatransfer.py
@@ -208,6 +208,8 @@ def poll(process_id, nconsumers, queue, schema, kafka_config, rng, args):
                                 partitioning = ["tnsclass"]
                             elif args.partitionby == "classId":
                                 partitioning = ["classId"]
+                            else:
+                                partitioning = None
 
                             table = pa.Table.from_pandas(pdf)
 
@@ -332,7 +334,7 @@ def main():
     )
     args = parser.parse_args(None)
 
-    if args.partitionby not in ["time", "finkclass", "tnsclass", "classId"]:
+    if args.partitionby is not None and args.partitionby not in ["time", "finkclass", "tnsclass", "classId"]:
         _LOG.error(
             "{} is an unknown partitioning. `-partitionby` should be in ['time', 'finkclass', 'tnsclass', 'classId']".format(
                 args.partitionby

--- a/fink_client/scripts/fink_datatransfer.py
+++ b/fink_client/scripts/fink_datatransfer.py
@@ -290,8 +290,8 @@ def main():
     parser.add_argument(
         "-partitionby",
         type=str,
-        default="time",
-        help="Partition data by `time` (year=YYYY/month=MM/day=DD), or `finkclass` (finkclass=CLASS), or `tnsclass` (tnsclass=CLASS). `classId` is also available for ELASTiCC data. Default is time.",
+        default=None,
+        help="Partition data by `time` (year=YYYY/month=MM/day=DD), or `finkclass` (finkclass=CLASS), or `tnsclass` (tnsclass=CLASS). `classId` is also available for ELASTiCC data. Default is None, that is no partitioning is applied.",
     )
     parser.add_argument(
         "-batchsize",


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #215 

## What changes were proposed in this pull request?

Data from the Data Transfer service can be downloaded without a specific partitioning scheme.

## How was this patch tested?

Manual
