### PR TITLE
Enable fxmatch_ topics in the datatransfer

### DIFF
--- a/fink_client/scripts/fink_datatransfer.py
+++ b/fink_client/scripts/fink_datatransfer.py
@@ -347,10 +347,10 @@ def main():
         )
         sys.exit()
 
-    if not args.topic.startswith("ftransfer"):
+    if not (args.topic.startswith("ftransfer") or args.topic.startswith("fxmatch")):
         msg = """
 {} is not a valid topic name.
-Topic name must start with `ftransfer_`.
+Topic name must start with `ftransfer_` or `fxmatch_`.
 Check the webpage on which you submit the job,
 and open the tab `Get your data` to retrieve the topic.
         """.format(args.topic)


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #217 

## What changes were proposed in this pull request?

Enable topics starting with `fxmatch_` to be downloaded.

## How was this patch tested?

Manual.