### PR TITLE
[Data Transfer] Replace consume by poll

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Depending on the survey used, you will find documentation at:
 |-|-|
 | Livestream | [LSST](https://doc.lsst.fink-broker.org/services/livestream/) / [ZTF](https://doc.ztf.fink-broker.org/en/latest/services/livestream/) |
 | Data Transfer | [LSST](https://doc.lsst.fink-broker.org/services/data_transfer/) / [ZTF](https://doc.ztf.fink-broker.org/en/latest/services/data_transfer/) |
-| Xmatch | LSST (to come) / [ZTF](https://doc.ztf.fink-broker.org/en/latest/services/xmatch/) |
+| Xmatch | [LSST](https://doc.lsst.fink-broker.org/services/data_transfer/) (incl. in Data Transfer) / [ZTF](https://doc.ztf.fink-broker.org/en/latest/services/xmatch/) |
 
 
 ## Registration

--- a/fink_client/scripts/fink_datatransfer.py
+++ b/fink_client/scripts/fink_datatransfer.py
@@ -131,7 +131,13 @@ def poll(
             poll_number = initial
             try:
                 while poll_number < maxpoll:
-                    msgs = consumer.consume(args.batchsize, args.maxtimeout)
+                    msgs = []
+                    for _ in range(args.batchsize):
+                        msg = consumer.poll(args.maxtimeout)
+                        if msg is not None:
+                            msgs.append(msg)
+                        else:
+                            break
                     # Decode the message
                     if msgs is not None:
                         if len(msgs) == 0:

--- a/fink_client/scripts/fink_datatransfer.py
+++ b/fink_client/scripts/fink_datatransfer.py
@@ -269,8 +269,8 @@ Default is None, that is no partitioning is applied (all parquet files in the `o
     parser.add_argument(
         "-batchsize",
         type=int,
-        default=1000,
-        help="Maximum number of alert within the `maxtimeout` (see conf). Default is 1000 alerts.",
+        default=100,
+        help="Maximum number of alert within the `maxtimeout` (see conf). Default is 100 alerts.",
     )
     parser.add_argument(
         "-nconsumers",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
     description="Light-weight client to manipulate alerts from Fink",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://doc.lsst.fink-broker.org/en/latest/",
+    url="https://doc.lsst.fink-broker.org",
     install_requires=requirements,
     packages=setuptools.find_packages(),
     entry_points={
@@ -54,7 +54,7 @@ setuptools.setup(
         "Intended Audience :: Science/Research",
     ],
     project_urls={
-        "Documentation": "https://doc.lsst.fink-broker.org/en/latest/",
+        "Documentation": "https://doc.lsst.fink-broker.org/",
         "Source": "https://github.com/astrolabsoftware/fink-client",
     },
 )


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #262

## What changes were proposed in this pull request?

This PR replaces the method `consume` when polling in the Data Transfer by the method `poll`. This is more reliable given a timeout.

## How was this patch tested?

Manual
