### PR TITLE
PoC for bots

### DIFF
--- a/fink_client/botlib.py
+++ b/fink_client/botlib.py
@@ -1,0 +1,553 @@
+# Copyright 2023-2026 AstroLab Software
+# Author: Тимофей Пшеничный, Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Part of these functionalities were initially taken from the Anomaly detection module"""
+
+import os
+import io
+import time
+import requests
+import pandas as pd
+import numpy as np
+import gzip
+import re
+from astropy.io import fits
+
+import matplotlib.pyplot as plt
+
+
+from fink_client.visualisation import extract_field
+
+COLORS_ZTF = {1: "#15284F", 2: "#F5622E"}
+
+
+def escape(text):
+    """Escapes the text as needed for MarkdownV2 parse_mode
+
+    Parameters
+    ----------
+    text : Text to escape
+
+    Returns
+    -------
+        result : str
+    """
+    return re.sub(r"[_*[\]()~>#\+\-=|{}.!]", lambda x: "\\" + x.group(), text)
+
+
+def status_check(res, header, sleep=8, timeout=25, token=None):
+    """Checks whether the request was successful.
+
+    In case of an error, sends information about the error to the @fink_test telegram channel
+
+    Parameters
+    ----------
+    res : Response object
+
+    Returns
+    -------
+        result : bool
+            True : The request was successful
+            False: The request was executed with an error
+    """
+    if res.status_code != 200:
+        msg = """
+        {}
+        Content: {}
+        """.format(header, res.content)
+        url = "https://api.telegram.org/bot"
+        url += token or os.environ["FINK_TG_TOKEN"]
+        method = url + "/sendMessage"
+        time.sleep(sleep)
+        requests.post(
+            method, data={"chat_id": "@fink_bot_error", "text": msg}, timeout=timeout
+        )
+        return False
+    return True
+
+
+def send_simple_text_tg(text, channel_id, timeout=25, token=None):
+    """Send a text message to a telegram channel
+
+    Parameters
+    ----------
+    text: str
+        Message to send. Accept markdown.
+    channel_id: string
+        Channel id in Telegram
+    timeout: int
+        Timeout, in seconds. Default is 25 seconds.
+    """
+    url = "https://api.telegram.org/bot"
+    url += token or os.environ["FINK_TG_TOKEN"]
+
+    if text != "":
+        res = requests.post(
+            url + "/sendMessage",
+            data={"chat_id": channel_id, "text": text, "parse_mode": "markdown"},
+            timeout=timeout,
+        )
+        status_check(res, header=channel_id)
+
+
+def msg_handler_tg(
+    tg_data,
+    channel_id,
+    init_msg=None,
+    timeout=25,
+    sleep_seconds=10,
+    parse_mode="markdown",
+    token=None,
+):
+    """Send `tg_data` to a telegram channel
+
+    Notes
+    -----
+    The function sends notifications to the "channel_id" channel of Telegram.
+
+    Parameters
+    ----------
+    tg_data: list
+        List of tuples. Each item is a separate notification.
+        Content of the tuple:
+            text_data : str
+                Notification text
+            cutout : BytesIO stream or str
+                cutout image in png format, image url, or a list of these
+            curve : BytesIO stream
+                light curve picture
+    channel_id: string
+        Channel id in Telegram
+    init_msg: str
+        Initial message
+    timeout: int
+        Timeout when sending message. Default is 25 seconds.
+    sleep_seconds: int
+        How many seconds to sleep between two messages to avoid
+        code 429 from the Telegram API. Default is 10 seconds.
+
+    Returns
+    -------
+        None
+    """
+    url = "https://api.telegram.org/bot"
+    url += token or os.environ["FINK_TG_TOKEN"]
+    method = url + "/sendMediaGroup"
+
+    def add(data, text=None, parse_mode=parse_mode):
+        # TODO: handle text-only messages?
+        item = {
+            "type": "photo",
+        }
+
+        if isinstance(data, str):
+            item["media"] = data
+        elif data is not None:
+            fname = "file{}".format(len(files))
+            files[fname] = data
+            item["media"] = "attach://{}".format(fname)
+
+        if text is not None:
+            item["caption"] = text
+            item["parse_mode"] = parse_mode
+
+        media.append(item)
+
+    if init_msg:
+        send_simple_text_tg(init_msg, channel_id, timeout=timeout)
+    for text_data, cutout, curve in tg_data:
+        files = {}
+        media = []
+
+        if curve is not None:
+            add(curve, text_data)
+
+        if isinstance(cutout, list):
+            for c in cutout:
+                add(c)
+        elif cutout is not None:
+            add(cutout)
+
+        res = requests.post(
+            method,
+            params={"chat_id": channel_id, "media": str(media).replace("'", '"')},
+            files=files,
+            timeout=timeout,
+        )
+        status_check(res, header=channel_id)
+        time.sleep(sleep_seconds)
+
+
+def msg_handler_tg_cutouts(
+    tg_data, channel_id, init_msg, timeout=25, sleep_seconds=10, token=None
+):
+    """Multi-cutout version of `msg_handler_tg`
+
+    Notes
+    -----
+    The function sends notifications to the "channel_id" channel of Telegram.
+
+    Parameters
+    ----------
+    tg_data: list
+        List of tuples. Each item is a separate notification.
+        Content of the tuple:
+            text_data : str
+                Notification text
+            curve : BytesIO stream
+                light curve picture
+            cutouts : list of BytesIO stream
+                List of cutout images in png format (1, 2, or 3 cutouts)
+    channel_id: string
+        Channel id in Telegram
+    init_msg: str
+        Initial message
+    timeout: int
+        Timeout when sending message. Default is 25 seconds.
+    sleep_seconds: int
+        How many seconds to sleep between two messages to avoid
+        code 429 from the Telegram API. Default is 10 seconds.
+
+    Returns
+    -------
+        None
+    """
+    url = "https://api.telegram.org/bot"
+    url += token or os.environ["FINK_TG_TOKEN"]
+    method = url + "/sendMediaGroup"
+
+    if init_msg != "":
+        send_simple_text_tg(init_msg, channel_id, timeout=25)
+    for text_data, curve, cutouts in tg_data:
+        files = {"first": curve}
+        media = [
+            {
+                "type": "photo",
+                "media": "attach://first",
+                "caption": text_data,
+                "parse_mode": "markdown",
+            }
+        ]
+        if isinstance(cutouts, list):
+            names = ["second", "thrid", "fourth"]
+            for cutout, name in zip(cutouts, names):
+                files.update({name: cutout})
+                media.append({"type": "photo", "media": "attach://{}".format(name)})
+        res = requests.post(
+            method,
+            params={"chat_id": channel_id, "media": str(media).replace("'", '"')},
+            files=files,
+            timeout=timeout,
+        )
+        status_check(res, header=channel_id)
+        time.sleep(sleep_seconds)
+
+
+def get_cutout(cutout=None, ztf_id=None, kind="Difference", origin="alert"):
+    """Loads cutout image from alert packet or via Fink API
+
+    Parameters
+    ----------
+    cutout: bytes, optional
+        Gzipped FITS file from alert packet. Only
+        used for origin=alert.
+    ztf_id : str, optional
+        unique identifier for this object. Only
+        used for origin=API.
+    kind: str, optional
+        Science, Difference, or Template
+    origin: str, optional
+        Choose between `alert`[default], or API.
+
+    Returns
+    -------
+    out : BytesIO stream
+        cutout image in png format
+
+    Examples
+    --------
+    From API
+    >>> out = get_cutout(ztf_id="ZTF23aapvluy", origin="API", kind="Science")
+    >>> assert isinstance(out, io.BytesIO)
+
+    From cutout
+    >>> pdf = pd.read_parquet("../test_data/online/science/day=04/alert_samples.parquet")
+    >>> cutout = pdf["cutoutTemplate"].apply(lambda x: x["stampData"]).to_numpy()[0]
+    >>> out = get_cutout(cutout, kind="Science")
+    >>> assert isinstance(out, io.BytesIO)
+    """
+    if origin == "API":
+        assert ztf_id is not None
+        r = requests.post(
+            "https://api.ztf.fink-portal.org/api/v1/cutouts",
+            json={"objectId": ztf_id, "kind": kind, "output-format": "array"},
+            timeout=25,
+        )
+        if not status_check(r, header=ztf_id):
+            return io.BytesIO()
+        data = np.log(
+            np.array(r.json()["b:cutout{}_stampData".format(kind)], dtype=float)
+        )
+        plt.axis("off")
+        plt.imshow(data, cmap="PuBu_r")
+        buf = io.BytesIO()
+        plt.savefig(buf, format="png", bbox_inches="tight", pad_inches=0)
+        buf.seek(0)
+        plt.close()
+    elif origin == "alert":
+        assert cutout is not None
+
+        # Unzip
+        with gzip.open(io.BytesIO(cutout), "rb") as fits_file:
+            with fits.open(
+                io.BytesIO(fits_file.read()), ignore_missing_simple=True
+            ) as hdul:
+                img = hdul[0].data[::-1]
+
+        data = np.log(img)
+        plt.axis("off")
+        plt.imshow(data, cmap="PuBu_r")
+        buf = io.BytesIO()
+        plt.savefig(buf, format="png", bbox_inches="tight", pad_inches=0)
+        buf.seek(0)
+        plt.close()
+    else:
+        buf = io.BytesIO()
+
+    return buf
+
+
+def get_curve(
+    alert=None,
+    jd=None,
+    magpsf=None,
+    sigmapsf=None,
+    diffmaglim=None,
+    fid=None,
+    objectId=None,
+    origin="API",
+    ylabel="Difference magnitude",
+    title=None,
+    invert_yaxis=True,
+    vline=None,
+    hline=None,
+):
+    """Generate PNG lightcurve
+
+    Notes
+    -----
+    Based on `origin`, the other arguments are mandatory:
+    - origin=API: objectId
+    - origin=alert: alert
+    - origin=fields: objectId, jd, magpsf, sigmapsf, diffmaglim, fid
+
+    Parameters
+    ----------
+    alert: dict, optional
+        alert packet containing `objectId`, `candidate`, `prv_candidates`
+    jd: np.array, optional
+        Vector of times.
+    magpsf: np.array, optional
+        Vector of difference magnitudes.
+    sigmapsf: np.array, optional
+        Vector of error on difference magnitudes.
+    diffmaglim: np.array, optional
+        Vector of upper limits on magnitude.
+    fid: np.array, optional
+        Vector of filter ID.
+    objectId : str
+        unique identifier for this object
+    origin: str, optional
+        Choose between `alert`, `API`[default], or `fields`.
+    ylabel: str
+        Label for y-axis. Default is `Difference magnitude`
+    title: str
+        Title for the plot. If None, `objectId` will be used.
+        Default is None.
+    invert_yaxis: bool
+        Invert the y-axis. Default is True.
+    vline: None or dictionary
+        If specified, a dictionary with the following structure:
+            {"x": float, "x_label": str}
+        where "x" is the x value for the vertical line, and
+        "x_label" is the label that will appear on the legend.
+        Default is None.
+    hline: None or dictionary
+        If specified, a dictionary with the following structure:
+            {"y": float, "y_label": str}
+        where "y" is the y value for the horizontal line, and
+        "y_label" is the label that will appear on the legend.
+        Default is None.
+
+    Returns
+    -------
+    out : BytesIO stream
+        light curve picture
+    """
+    filter_dict = {1: "g band", 2: "r band"}
+    if origin == "API":
+        assert objectId is not None
+
+        r = requests.post(
+            "https://api.ztf.fink-portal.org/api/v1/objects",
+            json={
+                "objectId": objectId,
+                "columns": "i:jd,i:fid,i:magpsf,i:sigmapsf,d:tag",
+                "withupperlim": "True",
+            },
+        )
+        if not status_check(r, header=objectId):
+            return None
+
+        # Format output in a DataFrame
+        pdf = pd.read_json(io.BytesIO(r.content))
+
+        if pdf.empty:
+            return None
+
+        plt.figure(figsize=(12, 4))
+
+        for filt in pdf["i:fid"].unique():
+            if filt == 3:
+                continue
+            maskFilt = pdf["i:fid"] == filt
+
+            # The column `d:tag` is used to check data type
+            maskValid = pdf["d:tag"] == "valid"
+            plt.errorbar(
+                pdf[maskValid & maskFilt]["i:jd"].apply(lambda x: x - 2400000.5),
+                pdf[maskValid & maskFilt]["i:magpsf"],
+                pdf[maskValid & maskFilt]["i:sigmapsf"],
+                ls="",
+                marker="o",
+                color=COLORS_ZTF[filt],
+                label=filter_dict[filt],
+            )
+
+            # see fink-utils#78 & fink-broker#872
+            if "i:diffmaglim" in pdf.columns:
+                maskUpper = pdf["d:tag"] == "upperlim"
+                plt.plot(
+                    pdf[maskUpper & maskFilt]["i:jd"].apply(lambda x: x - 2400000.5),
+                    pdf[maskUpper & maskFilt]["i:diffmaglim"],
+                    ls="",
+                    marker="^",
+                    color=COLORS_ZTF[filt],
+                    markerfacecolor="none",
+                )
+
+            maskBadquality = pdf["d:tag"] == "badquality"
+            plt.errorbar(
+                pdf[maskBadquality & maskFilt]["i:jd"].apply(lambda x: x - 2400000.5),
+                pdf[maskBadquality & maskFilt]["i:magpsf"],
+                pdf[maskBadquality & maskFilt]["i:sigmapsf"],
+                ls="",
+                marker="v",
+                color=COLORS_ZTF[filt],
+            )
+
+        if vline is not None:
+            plt.axvline(vline["x"], ls="--", color="black", label=vline["x_label"])
+
+        if hline is not None:
+            plt.axhline(hline["y"], ls="--", color="black", label=hline["y_label"])
+
+        if invert_yaxis:
+            plt.gca().invert_yaxis()
+        plt.legend()
+        plt.xlabel("Modified Julian Date")
+        plt.ylabel(ylabel)
+
+        buf = io.BytesIO()
+        plt.savefig(buf, format="png")
+        buf.seek(0)
+        plt.close()
+
+    elif origin in ["alert", "fields"]:
+        if origin == "alert":
+            # extract current and historical data as one vector
+            magpsf = extract_field(alert, "magpsf")
+            sigmapsf = extract_field(alert, "sigmapsf")
+            diffmaglim = extract_field(alert, "diffmaglim")
+            fid = extract_field(alert, "fid")
+            jd = extract_field(alert, "jd")
+            objectId = alert["objectId"]
+
+        if title is None:
+            title = objectId
+
+        # Rescale dates
+        dates = np.array([i - jd[-1] for i in jd])
+
+        # work with arrays
+        fid = np.array(fid)
+        magpsf = np.array(magpsf)
+        sigmapsf = np.array(sigmapsf)
+        diffmaglim = np.array(diffmaglim)
+
+        # loop over filters
+        plt.figure(num=1, figsize=(12, 4))
+
+        # Loop over each filter
+        for filt in COLORS_ZTF.keys():
+            mask = np.where(fid == filt)[0]
+
+            # Skip if no data
+            if len(mask) == 0:
+                continue
+
+            # y data -- assume NaN (Spark style) and None (Pandas style) for missing values
+            maskNotNone = np.array([
+                (i is not None) and ~np.isnan(i) for i in magpsf[mask]
+            ])
+            plt.errorbar(
+                dates[mask][maskNotNone],
+                magpsf[mask][maskNotNone],
+                yerr=sigmapsf[mask][maskNotNone],
+                color=COLORS_ZTF[filt],
+                marker="o",
+                ls="",
+                label=filter_dict[filt],
+                mew=4,
+            )
+            # Upper limits
+            plt.plot(
+                dates[mask][~maskNotNone],
+                diffmaglim[mask][~maskNotNone],
+                color=COLORS_ZTF[filt],
+                marker="v",
+                ls="",
+                mew=4,
+                alpha=0.5,
+            )
+            plt.title(title)
+
+        if vline is not None:
+            plt.axvline(vline["x"], ls="--", color="black", label=vline["x_label"])
+
+        if hline is not None:
+            plt.axhline(hline["y"], ls="--", color="black", label=hline["y_label"])
+
+        plt.legend()
+        if invert_yaxis:
+            plt.gca().invert_yaxis()
+        plt.xlabel("Days to candidates")
+        plt.ylabel(ylabel)
+
+        buf = io.BytesIO()
+        plt.savefig(buf, format="png")
+        buf.seek(0)
+        plt.close()
+
+    return buf

--- a/fink_client/consumer.py
+++ b/fink_client/consumer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2019-2024 AstroLab Software
+# Copyright 2019-2026 AstroLab Software
 # Author: Abhishek Chauhan, Julien Peloton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/fink_client/handlers.py
+++ b/fink_client/handlers.py
@@ -22,7 +22,7 @@ from fink_client.consumer import extract_id_from_lsst
 from fink_client.avro_utils import write_alert
 from fink_client.visualisation import extract_field
 
-from fink_utils.tg_bot.utils import get_curve, get_cutout, msg_handler_tg
+from fink_client.botlib import get_curve, get_cutout, msg_handler_tg
 
 
 def display_alerts_as_table(survey, topic, alert, is_mma=False) -> None:
@@ -144,12 +144,9 @@ def send_to_telegram(alert, survey, token):
 
         cutout = get_cutout(cutout=alert["cutoutScience"]["stampData"])
 
-        text = """
-    *Object ID*: [{}](https://ztf.fink-portal.org/{})
-        """.format(
-            alert["objectId"],
-            alert["objectId"],
-        )
+        text = f"""
+    *Object ID*: [{alert["objectId"]}](https://ztf.fink-portal.org/{alert["objectId"]})
+        """
     elif survey == "lsst":
         mjds = extract_field(
             alert, "midpointMjdTai", current="diaSource", previous="prvDiaSources"
@@ -174,12 +171,9 @@ def send_to_telegram(alert, survey, token):
 
         cutout = get_cutout(cutout=alert["cutoutScience"])
 
-        text = """
-    *Object ID*: [{}](https://lsst.fink-portal.org/{})
-        """.format(
-            alert["diaSource"]["diaObjectId"],
-            alert["diaSource"]["diaObjectId"],
-        )
+        text = f"""
+    *Object ID*: [{alert["diaSource"]["diaObjectId"]}](https://lsst.fink-portal.org/{alert["diaSource"]["diaObjectId"]})
+        """
 
     msg_handler_tg(
         [(text, curve_png, cutout)],

--- a/fink_client/handlers.py
+++ b/fink_client/handlers.py
@@ -16,12 +16,13 @@
 import time
 
 from astropy.time import Time
+from tabulate import tabulate
 
 from fink_client.consumer import extract_id_from_lsst
 from fink_client.avro_utils import write_alert
 
 
-def display_alerts_as_table(survey, topic, alert, is_mma=False):
+def display_alerts_as_table(survey, topic, alert, is_mma=False) -> None:
     """Display table based on input survey
 
     Parameters
@@ -35,10 +36,6 @@ def display_alerts_as_table(survey, topic, alert, is_mma=False):
     is_mma: bool, optional
         If True, assumes MMA topics (ZTF only).
 
-    Returns
-    -------
-    table: list of list
-    header: list of str
     """
     utc = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())
     if survey == "ztf":
@@ -93,7 +90,8 @@ def display_alerts_as_table(survey, topic, alert, is_mma=False):
             ]
         ]
         header = ["Emitted at (UTC)", "Received at (UTC)", "Topic", id_name]
-    return table, header
+
+    print(tabulate(table, header, tablefmt="pretty"))
 
 
 def store_alert(alert, schema, outdir, survey, is_mma, overwrite=True):

--- a/fink_client/handlers.py
+++ b/fink_client/handlers.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# Copyright 2019-2026 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import time
+
+from astropy.time import Time
+
+from fink_client.consumer import extract_id_from_lsst
+
+
+def display_alerts_as_table(survey, topic, alert, is_mma=False):
+    """Display table based on input survey
+
+    Parameters
+    ----------
+    survey: str
+        lsst or ztf
+    topic: str
+        Topic name
+    alert: dict
+        Dictionary containing alert data
+    is_mma: bool, optional
+        If True, assumes MMA topics (ZTF only).
+
+    Returns
+    -------
+    table: list of list
+    header: list of str
+    """
+    utc = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())
+    if survey == "ztf":
+        if is_mma:
+            table = [
+                [
+                    alert["objectId"],
+                    alert["fink_class"],
+                    topic,
+                    alert["rate"],
+                    alert["observatory"],
+                    alert["triggerId"],
+                ]
+            ]
+            header = [
+                "ObjectId",
+                "Classification",
+                "Topic",
+                "Rate (mag/day)",
+                "Observatory",
+                "Trigger ID",
+            ]
+        else:
+            table = [
+                [
+                    Time(alert["candidate"]["jd"], format="jd").iso,
+                    utc,
+                    topic,
+                    alert["objectId"],
+                    alert["cdsxmatch"],
+                    alert["candidate"]["magpsf"],
+                ],
+            ]
+            header = [
+                "Emitted at (UTC)",
+                "Received at (UTC)",
+                "Topic",
+                "objectId",
+                "Simbad",
+                "Magnitude",
+            ]
+    elif survey == "lsst":
+        id_value, id_name = extract_id_from_lsst(alert)
+        table = [
+            [
+                Time(
+                    alert["diaSource"]["midpointMjdTai"], format="mjd", scale="tai"
+                ).utc.iso,
+                utc,
+                topic,
+                id_value,
+            ]
+        ]
+        header = ["Emitted at (UTC)", "Received at (UTC)", "Topic", id_name]
+    return table, header
+
+
+def store_alerts():
+    """TBD"""
+    pass

--- a/fink_client/handlers.py
+++ b/fink_client/handlers.py
@@ -20,6 +20,9 @@ from tabulate import tabulate
 
 from fink_client.consumer import extract_id_from_lsst
 from fink_client.avro_utils import write_alert
+from fink_client.visualisation import extract_field
+
+from fink_utils.tg_bot.utils import get_curve, get_cutout, msg_handler_tg
 
 
 def display_alerts_as_table(survey, topic, alert, is_mma=False) -> None:
@@ -113,4 +116,74 @@ def store_alert(alert, schema, outdir, survey, is_mma, overwrite=True):
         overwrite=overwrite,
         id1=id1,
         id2=id2,
+    )
+
+
+def send_to_telegram(alert, survey, token):
+    """ """
+    if survey == "ztf":
+        curve_png = get_curve(
+            jd=extract_field(
+                alert, "jd", current="candidate", previous="prv_candidates"
+            ),
+            magpsf=extract_field(
+                alert, "magpsf", current="candidate", previous="prv_candidates"
+            ),
+            sigmapsf=extract_field(
+                alert, "sigmapsf", current="candidate", previous="prv_candidates"
+            ),
+            diffmaglim=extract_field(
+                alert, "diffmaglim", current="candidate", previous="prv_candidates"
+            ),
+            fid=extract_field(
+                alert, "fid", current="candidate", previous="prv_candidates"
+            ),
+            objectId=alert["objectId"],
+            origin="fields",
+        )
+
+        cutout = get_cutout(cutout=alert["cutoutScience"]["stampData"])
+
+        text = """
+    *Object ID*: [{}](https://ztf.fink-portal.org/{})
+        """.format(
+            alert["objectId"],
+            alert["objectId"],
+        )
+    elif survey == "lsst":
+        mjds = extract_field(
+            alert, "midpointMjdTai", current="diaSource", previous="prvDiaSources"
+        )
+        curve_png = get_curve(
+            jd=mjds,
+            magpsf=extract_field(
+                alert, "scienceFlux", current="diaSource", previous="prvDiaSources"
+            ),
+            sigmapsf=extract_field(
+                alert, "scienceFluxErr", current="diaSource", previous="prvDiaSources"
+            ),
+            diffmaglim=[None] * len(mjds),
+            fid=extract_field(
+                alert, "band", current="diaSource", previous="prvDiaSources"
+            ),
+            objectId=alert["diaSource"]["diaObjectId"],
+            origin="fields",
+            invert_yaxis=False,
+            ylabel="Science Flux [nJy]",
+        )
+
+        cutout = get_cutout(cutout=alert["cutoutScience"])
+
+        text = """
+    *Object ID*: [{}](https://lsst.fink-portal.org/{})
+        """.format(
+            alert["diaSource"]["diaObjectId"],
+            alert["diaSource"]["diaObjectId"],
+        )
+
+    msg_handler_tg(
+        [(text, curve_png, cutout)],
+        channel_id="@fink_client_bot_test",
+        init_msg="",
+        token=token,
     )

--- a/fink_client/handlers.py
+++ b/fink_client/handlers.py
@@ -18,6 +18,7 @@ import time
 from astropy.time import Time
 
 from fink_client.consumer import extract_id_from_lsst
+from fink_client.avro_utils import write_alert
 
 
 def display_alerts_as_table(survey, topic, alert, is_mma=False):
@@ -95,6 +96,23 @@ def display_alerts_as_table(survey, topic, alert, is_mma=False):
     return table, header
 
 
-def store_alerts():
+def store_alert(alert, schema, outdir, survey, is_mma, overwrite=True):
     """TBD"""
-    pass
+    if is_mma:
+        id1 = "objectId"
+        id2 = "triggerId"
+    elif survey == "ztf":
+        id1 = "objectId"
+        id2 = "candid"
+    elif survey == "lsst":
+        id1 = "diaSourceId"
+        id2 = None
+
+    write_alert(
+        alert,
+        schema,
+        outdir,
+        overwrite=overwrite,
+        id1=id1,
+        id2=id2,
+    )

--- a/fink_client/scripts/fink_consumer.py
+++ b/fink_client/scripts/fink_consumer.py
@@ -20,8 +20,6 @@ import os
 
 import argparse
 
-from tabulate import tabulate
-
 from fink_client.consumer import AlertConsumer
 from fink_client.handlers import display_alerts_as_table
 from fink_client.handlers import store_alert
@@ -189,7 +187,6 @@ def main():
                 is_mma = topic in mm_topic_names()
 
                 if args.save:
-                    # Save alert on disk
                     store_alert(
                         alert,
                         consumer._parsed_schema,
@@ -206,11 +203,7 @@ def main():
                     pass
 
                 if args.display:
-                    # Display small table
-                    table, header = display_alerts_as_table(
-                        conf["survey"], topic, alert, is_mma
-                    )
-                    print(tabulate(table, header, tablefmt="pretty"))
+                    display_alerts_as_table(conf["survey"], topic, alert, is_mma)
 
     except KeyboardInterrupt:
         sys.stderr.write("%% Aborted by user\n")

--- a/fink_client/scripts/fink_consumer.py
+++ b/fink_client/scripts/fink_consumer.py
@@ -23,6 +23,7 @@ import argparse
 from fink_client.consumer import AlertConsumer
 from fink_client.handlers import display_alerts_as_table
 from fink_client.handlers import store_alert
+from fink_client.handlers import send_to_telegram
 from fink_client.configuration import load_credentials
 from fink_client.configuration import mm_topic_names
 
@@ -197,7 +198,11 @@ def main():
                     )
 
                 if args.telegram:
-                    pass
+                    token = conf["tg_tokens"].get(topic, None)
+                    if token is None:
+                        print("You need to have a token for the topic {}".format(topic))
+                        break
+                    send_to_telegram(alert, args.survey, token)
 
                 if args.slack:
                     pass

--- a/fink_client/scripts/fink_consumer.py
+++ b/fink_client/scripts/fink_consumer.py
@@ -19,91 +19,16 @@ import sys
 import os
 
 import argparse
-import time
 
-from astropy.time import Time
 from tabulate import tabulate
 
-from fink_client.consumer import AlertConsumer, extract_id_from_lsst
+from fink_client.consumer import AlertConsumer
+from fink_client.handlers import display_alerts_as_table
+from fink_client.handlers import store_alerts
 from fink_client.configuration import load_credentials
 from fink_client.configuration import mm_topic_names
 
 from fink_client.consumer import print_offsets
-
-
-def display_table(survey, topic, alert, is_mma=False):
-    """Display table based on input survey
-
-    Parameters
-    ----------
-    survey: str
-        lsst or ztf
-    topic: str
-        Topic name
-    alert: dict
-        Dictionary containing alert data
-    is_mma: bool, optional
-        If True, assumes MMA topics (ZTF only).
-
-    Returns
-    -------
-    table: list of list
-    header: list of str
-    """
-    utc = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())
-    if survey == "ztf":
-        if is_mma:
-            table = [
-                [
-                    alert["objectId"],
-                    alert["fink_class"],
-                    topic,
-                    alert["rate"],
-                    alert["observatory"],
-                    alert["triggerId"],
-                ]
-            ]
-            header = [
-                "ObjectId",
-                "Classification",
-                "Topic",
-                "Rate (mag/day)",
-                "Observatory",
-                "Trigger ID",
-            ]
-        else:
-            table = [
-                [
-                    Time(alert["candidate"]["jd"], format="jd").iso,
-                    utc,
-                    topic,
-                    alert["objectId"],
-                    alert["cdsxmatch"],
-                    alert["candidate"]["magpsf"],
-                ],
-            ]
-            header = [
-                "Emitted at (UTC)",
-                "Received at (UTC)",
-                "Topic",
-                "objectId",
-                "Simbad",
-                "Magnitude",
-            ]
-    elif survey == "lsst":
-        id_value, id_name = extract_id_from_lsst(alert)
-        table = [
-            [
-                Time(
-                    alert["diaSource"]["midpointMjdTai"], format="mjd", scale="tai"
-                ).utc.iso,
-                utc,
-                topic,
-                id_value,
-            ]
-        ]
-        header = ["Emitted at (UTC)", "Received at (UTC)", "Topic", id_name]
-    return table, header
 
 
 def main():
@@ -275,7 +200,9 @@ def main():
 
                 if args.display:
                     # Display small table
-                    table, header = display_table(conf["survey"], topic, alert, is_mma)
+                    table, header = display_alerts_as_table(
+                        conf["survey"], topic, alert, is_mma
+                    )
                     print(tabulate(table, header, tablefmt="pretty"))
 
     except KeyboardInterrupt:

--- a/fink_client/scripts/fink_consumer.py
+++ b/fink_client/scripts/fink_consumer.py
@@ -24,7 +24,7 @@ from tabulate import tabulate
 
 from fink_client.consumer import AlertConsumer
 from fink_client.handlers import display_alerts_as_table
-from fink_client.handlers import store_alerts
+from fink_client.handlers import store_alert
 from fink_client.configuration import load_credentials
 from fink_client.configuration import mm_topic_names
 
@@ -189,8 +189,15 @@ def main():
                 is_mma = topic in mm_topic_names()
 
                 if args.save:
-                    # Save alerts on disk
-                    store_alerts(outdir=args.outdir, overwrite=True)
+                    # Save alert on disk
+                    store_alert(
+                        alert,
+                        consumer._parsed_schema,
+                        survey=args.survey,
+                        is_mma=is_mma,
+                        outdir=args.outdir,
+                        overwrite=True,
+                    )
 
                 if args.telegram:
                     pass

--- a/fink_client/scripts/fink_consumer.py
+++ b/fink_client/scripts/fink_consumer.py
@@ -116,30 +116,16 @@ def main():
         help="Survey name among ztf or lsst. Note that each survey has its own configuration file.",
     )
     parser.add_argument(
-        "--display",
-        action="store_true",
-        help="If specified, print on screen information about incoming alert.",
-    )
-    parser.add_argument(
-        "--display_statistics",
-        action="store_true",
-        help="If specified, print on screen information about queues, and exit.",
-    )
-    parser.add_argument(
         "-limit",
         type=int,
         default=None,
         help="If specified, download only `limit` alerts. Default is None.",
     )
     parser.add_argument(
-        "--available_topics",
-        action="store_true",
-        help="If specified, print on screen information about available topics.",
-    )
-    parser.add_argument(
-        "--save",
-        action="store_true",
-        help="If specified, save alert data on disk (Avro). See also -outdir.",
+        "-start_at",
+        type=str,
+        default="",
+        help=r"If specified, reset offsets to 0 (`earliest`) or empty queue (`latest`).",
     )
     parser.add_argument(
         "-outdir",
@@ -154,15 +140,39 @@ def main():
         help="Avro schema to decode the incoming alerts. Default is None (version taken from each alert)",
     )
     parser.add_argument(
-        "--dump_schema",
+        "--available_topics",
         action="store_true",
-        help="If specified, save the schema on disk (json file)",
+        help="If specified, print on screen information about available topics, and exit.",
     )
     parser.add_argument(
-        "-start_at",
-        type=str,
-        default="",
-        help=r"If specified, reset offsets to 0 (`earliest`) or empty queue (`latest`).",
+        "--display_statistics",
+        action="store_true",
+        help="If specified, print on screen information about queues, and exit.",
+    )
+    parser.add_argument(
+        "--display",
+        action="store_true",
+        help="If specified, print on screen information about incoming alert.",
+    )
+    parser.add_argument(
+        "--save",
+        action="store_true",
+        help="If specified, save alert data on disk (Avro). See also -outdir.",
+    )
+    parser.add_argument(
+        "--telegram",
+        action="store_true",
+        help="If specified, redirect alerts on a Telegram channel.",
+    )
+    parser.add_argument(
+        "--slack",
+        action="store_true",
+        help="If specified, redirect alerts on a Slack channel.",
+    )
+    parser.add_argument(
+        "--dump_schema",
+        action="store_true",
+        help="If specified, save the schema on disk (json file) before polling.",
     )
     args = parser.parse_args(None)
 
@@ -244,25 +254,30 @@ def main():
     try:
         poll_number = 0
         while poll_number < maxpoll:
-            if args.save:
-                # Save alerts on disk
-                topic, alert, _ = consumer.poll_and_write(
-                    outdir=args.outdir, timeout=maxtimeout, overwrite=True
-                )
-            else:
-                # TODO: this is useless to get it and done nothing
-                # why not thinking about handler like Comet?
-                topic, alert, _ = consumer.poll(timeout=maxtimeout)
+            topic, alert, _ = consumer.poll(timeout=maxtimeout)
 
-            if topic is not None:
+            if alert is None:
+                if args.display:
+                    print("No alerts the last {} seconds".format(maxtimeout))
+            else:
                 poll_number += 1
                 is_mma = topic in mm_topic_names()
 
-            if args.display and topic is not None:
-                table, header = display_table(conf["survey"], topic, alert, is_mma)
-                print(tabulate(table, header, tablefmt="pretty"))
-            elif args.display:
-                print("No alerts the last {} seconds".format(maxtimeout))
+                if args.save:
+                    # Save alerts on disk
+                    store_alerts(outdir=args.outdir, overwrite=True)
+
+                if args.telegram:
+                    pass
+
+                if args.slack:
+                    pass
+
+                if args.display:
+                    # Display small table
+                    table, header = display_table(conf["survey"], topic, alert, is_mma)
+                    print(tabulate(table, header, tablefmt="pretty"))
+
     except KeyboardInterrupt:
         sys.stderr.write("%% Aborted by user\n")
     finally:


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #265

## What changes were proposed in this pull request?

This PR is a PoC for bots. It introduces the minimum structure for handling bots:
- handler module
- bot module

Only the telegram ZTF bots works:

```bash
fink_consume -survey ztf --telegram
```

and it expects the configuration file to reads:

```yaml
tg_tokens:
    <FILTERNAME>: <TOKEN>
```

The next steps will be to 
- expand to LSST
- expand to Slack
- expand the registration step to add bot registration
- restructure the client to have only one controller 
- enable daemon mode?

## How was this patch tested?

Manual
